### PR TITLE
Bundle LAPACK and BLAS libraries in IpOpt Linux build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -302,7 +302,7 @@ jobs:
             '
       # Verify library compatibility by checking that all shared library dependencies
       # resolve correctly. This ensures libipopt.so and bundled libraries (libgfortran,
-      # libgcc_s, libquadmath) can be loaded without missing symbols.
+      # libgcc_s, libquadmath, libblas, liblapack) can be loaded without missing symbols.
       - name: Verify Library Dependencies
         run: |
           echo "==> Verifying library dependencies for libipopt.so..."
@@ -317,7 +317,7 @@ jobs:
           # Verify that bundled libraries are present and have compatible dependencies.
           # Use nullglob to safely handle glob patterns that don't match any files.
           shopt -s nullglob
-          for lib in libgfortran.so.* libgcc_s.so.* libquadmath.so.*; do
+          for lib in libgfortran.so.* libgcc_s.so.* libquadmath.so.* libblas.so.* liblapack.so.*; do
             echo ""
             echo "==> Dependencies for $lib:"
             ldd "$lib" || true

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 0.9.49
+* bundled LAPACK and BLAS libraries in Linux IpOpt build for full self-contained distribution
+
 ### 0.9.48
 * improved Linux IpOpt native library compatibility by building in Ubuntu 18.04 Docker container
 * bundled libgfortran and runtime libraries are now compatible with older Linux distributions


### PR DESCRIPTION
The Linux IpOpt build now includes libblas and liblapack in the bundled output.
This ensures the library is self-contained and doesn't depend on system-installed
BLAS/LAPACK libraries.

Changes:
- Updated buildIpOptLinux.sh to detect and copy libblas.so.* and liblapack.so.*
- Set RPATH to $ORIGIN for all bundled libraries
- Strip debug symbols from BLAS and LAPACK libraries
- Updated CI verification step to check for BLAS/LAPACK dependencies