### PR TITLE
Replace mono/nuget.exe with dotnet nuget commands

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,19 +10,22 @@ jobs:
   ceres_mac_x64:
     name: Ceres MacOS (x64)
     runs-on: macos-15-intel
-    steps:  
+    steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install Dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
       - name: 'Setup NuGet Credentials'
         shell: 'bash'
         run: >
-          mono .config/nuget.exe
-          sources add
-          -source "https://nuget.pkg.github.com/aardvark-community/index.json"
-          -storepasswordincleartext
-          -name "GitHub"
-          -username "aardvark-community"
-          -password "${{ secrets.GITHUB_TOKEN }}"
+          dotnet nuget add source
+          "https://nuget.pkg.github.com/aardvark-community/index.json"
+          --name "GitHub"
+          --username "aardvark-community"
+          --password "${{ secrets.GITHUB_TOKEN }}"
+          --store-password-in-clear-text
       # - name: Setup Fortran
       #   uses: awvwgk/setup-fortran@main
       #   with:
@@ -30,12 +33,8 @@ jobs:
       #     version: 11
       - name: Build Native Libraries
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./buildnative.sh x86_64
-      - name: Install Dotnet 
-        uses: actions/setup-dotnet@v4
-        with:
-          global-json-file: global.json
       - name: Restore Tools
         run: dotnet tool restore
       - name: Restore
@@ -53,16 +52,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install Dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
       - name: 'Setup NuGet Credentials'
         shell: 'bash'
         run: >
-          mono .config/nuget.exe
-          sources add
-          -source "https://nuget.pkg.github.com/aardvark-community/index.json"
-          -storepasswordincleartext
-          -name "GitHub"
-          -username "aardvark-community"
-          -password "${{ secrets.GITHUB_TOKEN }}"
+          dotnet nuget add source
+          "https://nuget.pkg.github.com/aardvark-community/index.json"
+          --name "GitHub"
+          --username "aardvark-community"
+          --password "${{ secrets.GITHUB_TOKEN }}"
+          --store-password-in-clear-text
       # - name: Setup Fortran
       #   uses: awvwgk/setup-fortran@main
       #   with:
@@ -72,10 +74,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./buildnative.sh arm64
-      - name: Install Dotnet
-        uses: actions/setup-dotnet@v4
-        with:
-          global-json-file: global.json
       - name: Restore Tools
         run: dotnet tool restore
       - name: Restore
@@ -90,27 +88,26 @@ jobs:
   ceres_linux_x64:
     name: Ceres Linux (x64)
     runs-on: ubuntu-22.04
-    steps:  
+    steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: 'Setup NuGet Credentials'
-        shell: 'bash'
-        run: >
-          mono .config/nuget.exe
-          sources add
-          -source "https://nuget.pkg.github.com/aardvark-community/index.json"
-          -storepasswordincleartext
-          -name "GitHub"
-          -username "aardvark-community"
-          -password "${{ secrets.GITHUB_TOKEN }}"
-      - name: Build Native Libraries
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
-        run: ./buildnative.sh
       - name: Install Dotnet
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
+      - name: 'Setup NuGet Credentials'
+        shell: 'bash'
+        run: >
+          dotnet nuget add source
+          "https://nuget.pkg.github.com/aardvark-community/index.json"
+          --name "GitHub"
+          --username "aardvark-community"
+          --password "${{ secrets.GITHUB_TOKEN }}"
+          --store-password-in-clear-text
+      - name: Build Native Libraries
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./buildnative.sh
       - name: Restore Tools
         run: dotnet tool restore
       - name: Restore
@@ -169,16 +166,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install Dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
       - name: 'Setup NuGet Credentials'
         shell: 'bash'
         run: >
-          mono .config/nuget.exe
-          sources add
-          -source "https://nuget.pkg.github.com/aardvark-community/index.json"
-          -storepasswordincleartext
-          -name "GitHub"
-          -username "aardvark-community"
-          -password "${{ secrets.GITHUB_TOKEN }}"
+          dotnet nuget add source
+          "https://nuget.pkg.github.com/aardvark-community/index.json"
+          --name "GitHub"
+          --username "aardvark-community"
+          --password "${{ secrets.GITHUB_TOKEN }}"
+          --store-password-in-clear-text
       - name: Install gfortran
         run: |
           brew install gcc
@@ -187,10 +187,6 @@ jobs:
           echo "FC=$FC" >> $GITHUB_ENV
       - name: Build IpOpt Native Libraries
         run: ./buildIpOptMac.sh x86_64
-      - name: Install Dotnet
-        uses: actions/setup-dotnet@v4
-        with:
-          global-json-file: global.json
       - name: Restore Tools
         run: dotnet tool restore
       - name: Restore
@@ -209,16 +205,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install Dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
       - name: 'Setup NuGet Credentials'
         shell: 'bash'
         run: >
-          mono .config/nuget.exe
-          sources add
-          -source "https://nuget.pkg.github.com/aardvark-community/index.json"
-          -storepasswordincleartext
-          -name "GitHub"
-          -username "aardvark-community"
-          -password "${{ secrets.GITHUB_TOKEN }}"
+          dotnet nuget add source
+          "https://nuget.pkg.github.com/aardvark-community/index.json"
+          --name "GitHub"
+          --username "aardvark-community"
+          --password "${{ secrets.GITHUB_TOKEN }}"
+          --store-password-in-clear-text
       - name: Install gfortran
         run: |
           brew install gcc
@@ -227,10 +226,6 @@ jobs:
           echo "FC=$FC" >> $GITHUB_ENV
       - name: Build IpOpt Native Libraries
         run: ./buildIpOptMac.sh arm64
-      - name: Install Dotnet
-        uses: actions/setup-dotnet@v4
-        with:
-          global-json-file: global.json
       - name: Restore Tools
         run: dotnet tool restore
       - name: Restore

--- a/buildnative.sh
+++ b/buildnative.sh
@@ -8,7 +8,7 @@ ARCH_FLAGS=""
 
 a="/$0"; a=${a%/*}; a=${a#/}; a=${a:-.}; BASEDIR=$(cd "$a"; pwd)
 
-mono .config/nuget.exe setApiKey -Source GitHub $GITHUB_TOKEN -NonInteractive
+dotnet nuget update source "GitHub" --username "aardvark-community" --password "$GITHUB_TOKEN" --store-password-in-clear-text
 
 rm -dfr .vcpkg
 mkdir .vcpkg


### PR DESCRIPTION
Modern macOS runners (macos-15, macos-14) no longer have mono pre-installed,
causing publish actions to fail. This change replaces all mono-based NuGet
commands with native dotnet CLI equivalents:

- Replaced 'mono .config/nuget.exe sources add' with 'dotnet nuget add source'
- Replaced 'mono .config/nuget.exe setApiKey' with 'dotnet nuget update source'
- Moved dotnet installation step before NuGet credential setup to ensure
  dotnet is available when needed

The dotnet CLI NuGet commands are cross-platform and don't require mono,
resolving the macOS x64 publish failure while maintaining functionality
across all platforms (macOS, Linux, Windows).